### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "mc-ping-updated": "0.1.0",
     "mcpe-ping-fixed": "0.0.3",
     "mime": "1.3.4",
-    "request": "2.65.0",
+    "request": "2.74.0",
     "socket.io": "1.3.7",
     "sqlite3": "3.1.1",
     "winston": "2.0.0"


### PR DESCRIPTION
Minetrack currently has a 11 vulnerable dependency paths, introducing 6 different types of known vulnerabilities.

This PR fixes  vulnerable dependencies, [ReDOS vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/Cryptkeeper/Minetrack) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix all the vulnerabilities listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade others dependencies as well.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)